### PR TITLE
Prefer using SSH protocol for GitHub remote

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="https://github.com" name="github"/>
+  <remote fetch="ssh://git@github.com" name="github"/>
   <remote fetch="git://git.yoctoproject.org" name="yocto"/>
   <remote fetch="git://git.openembedded.org" name="oe"/>
 


### PR DESCRIPTION
The SSH is mostly standard and is available for every repository as
read-only so using it allow easier pushing for users when there is the
need.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>