### PR TITLE
Fix fetch error because git protocol was removed on GitHub

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="git://github.com" name="github"/>
+  <remote fetch="https://github.com" name="github"/>
   <remote fetch="git://git.yoctoproject.org" name="yocto"/>
   <remote fetch="git://git.openembedded.org" name="oe"/>
 


### PR DESCRIPTION
GitHub changed the git protocol to https for security reasons, causing links using git:// to break,making it necessary to change to https://.